### PR TITLE
WIP Fix datatype: Exercise 3 getCountsByPetType test

### DIFF
--- a/docs/pet-kata/slides.md
+++ b/docs/pet-kata/slides.md
@@ -789,7 +789,7 @@ Get counts by pet type
 @Test
 public void getCountsByPetType()
 {
-  MutableBag<PetType> counts =
+  Bag<PetType> counts =
     this.people.flatCollect(Person::getPets).countBy(Pet::getType);
 
   Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));

--- a/docs/pet-kata/slides.md
+++ b/docs/pet-kata/slides.md
@@ -988,7 +988,8 @@ public void streamsToECRefactor3()
     .asLazy()
     .flatCollect(Person::getPets)
     .countBy(Pet::getType)
-    .topOccurrences(3);
+    .topOccurrences(3)
+    .toList();
 
   Verify.assertSize(3, favorites);
   Verify.assertContains(PrimitiveTuples.pair(PetType.CAT, 2), favorites);


### PR DESCRIPTION
The datatype in the Exercise 3 solutions - `getCountsByPetType` test had the incorrect datatype in the solution documentation.  This change fixes that.

From
- `MutableBag<PetType> counts`

To 
- `Bag<PetType> counts`